### PR TITLE
feat(mobile): replace hamburger with floating pill + bottom sheet nav

### DIFF
--- a/blogs/blog.css
+++ b/blogs/blog.css
@@ -249,29 +249,89 @@
 /* Custom blog header styles removed to defer to global style.css */
 
 
-.sidebar-toggle {
-    display: none;
-    background: transparent !important;
-    color: var(--text-muted) !important;
-    border: none;
-    border-radius: 6px;
-    cursor: pointer;
-    padding: 0.4rem 0.5rem;
-    transition: all 0.25s var(--ease);
+/* ---------- DRAG HANDLE (mobile bottom sheet) ---------- */
+.sidebar-drag-handle {
+    display: none; /* shown only on mobile via media query */
+    width: 40px;
+    height: 4px;
+    background: var(--border);
+    border-radius: 100px;
+    margin: 12px auto 0;
+    flex-shrink: 0;
+    cursor: grab;
+}
+
+/* ---------- FLOATING BOTTOM PILL (mobile only) ---------- */
+.mobile-posts-pill {
+    display: none; /* shown via media query */
+    position: fixed;
+    bottom: 1.75rem;
+    left: 50%;
+    transform: translateX(-50%) translateY(0);
+    z-index: 300;
     align-items: center;
-    justify-content: center;
+    gap: 0.5rem;
+    padding: 0.75rem 1.4rem;
+    background: var(--accent);
+    color: #fff;
+    border: none;
+    border-radius: 100px;
+    font-family: var(--font);
+    font-size: 0.9rem;
+    font-weight: 600;
+    cursor: pointer;
+    white-space: nowrap;
+    box-shadow:
+        0 4px 24px rgba(108, 99, 255, 0.45),
+        0 1px 4px rgba(0,0,0,0.15);
+    transition:
+        transform 0.35s cubic-bezier(0.32, 0.72, 0, 1),
+        opacity   0.3s ease,
+        box-shadow 0.25s ease;
+    animation: pillEntrance 0.6s cubic-bezier(0.32, 0.72, 0, 1) 0.4s both;
 }
 
-.sidebar-toggle:hover {
-    background: rgba(108, 99, 255, 0.08) !important;
-    color: var(--text) !important;
+@keyframes pillEntrance {
+    from {
+        opacity: 0;
+        transform: translateX(-50%) translateY(24px);
+    }
+    to {
+        opacity: 1;
+        transform: translateX(-50%) translateY(0);
+    }
 }
 
-.sidebar-toggle-icon {
-    width: 20px;
-    height: 20px;
-    transition: color 0.25s var(--ease);
+.mobile-posts-pill:hover {
+    box-shadow:
+        0 6px 32px rgba(108, 99, 255, 0.55),
+        0 2px 8px rgba(0,0,0,0.18);
+    transform: translateX(-50%) translateY(-2px);
 }
+
+.mobile-posts-pill:active {
+    transform: translateX(-50%) translateY(0);
+}
+
+/* Sheet is open — pill stays visible, chevron flips to signal "tap to close" */
+.mobile-posts-pill.active {
+    background: rgba(80, 72, 200, 0.95);
+    box-shadow:
+        0 4px 24px rgba(108, 99, 255, 0.35),
+        0 1px 4px rgba(0,0,0,0.2);
+}
+
+.pill-chevron {
+    transition: transform 0.35s cubic-bezier(0.32, 0.72, 0, 1);
+    flex-shrink: 0;
+}
+
+/* Chevron points down = close action */
+.mobile-posts-pill.active .pill-chevron {
+    transform: rotate(180deg);
+}
+
+.pill-icon { flex-shrink: 0; }
 
 #theme-toggle {
     border-color: var(--border) !important;
@@ -611,23 +671,42 @@
         grid-template-columns: 1fr;
     }
 
+    /* Bottom sheet sidebar */
     .blog-sidebar {
         position: fixed;
-        top: 64px;
+        bottom: 0;
         left: 0;
-        width: 300px;
-        height: calc(100vh - 64px);
-        transform: translateX(-100%);
-        transition: transform 0.3s var(--ease);
+        right: 0;
+        top: auto;
+        width: 100%;
+        height: 85vh;
+        border-radius: 20px 20px 0 0;
+        border-right: none;
+        border-top: 1px solid var(--border);
+        transform: translateY(100%);
+        transition: transform 0.4s cubic-bezier(0.32, 0.72, 0, 1);
         box-shadow: none;
+        z-index: 200;
+        overflow-y: auto;
     }
 
     .blog-sidebar.open {
-        transform: translateX(0);
-        box-shadow: 4px 0 30px rgba(0,0,0,0.2);
+        transform: translateY(0);
+        box-shadow: 0 -8px 48px rgba(0, 0, 0, 0.25);
     }
 
+    /* Show drag handle on mobile */
+    .sidebar-drag-handle {
+        display: block;
+    }
+
+    /* Hide old nav hamburger button entirely on mobile */
     .sidebar-toggle {
+        display: none !important;
+    }
+
+    /* Show floating pill */
+    .mobile-posts-pill {
         display: flex;
     }
 
@@ -638,7 +717,7 @@
     }
 
     .blog-content {
-        padding: 2rem 1.5rem 4rem;
+        padding: 2rem 1.5rem 6rem; /* extra bottom padding so pill doesn't overlap content */
     }
 
     /* Mobile Nav Spacing */
@@ -651,12 +730,13 @@
     .sidebar-overlay {
         position: fixed;
         inset: 0;
-        top: 64px;
-        background: rgba(0,0,0,0.4);
-        z-index: 9;
+        background: rgba(0, 0, 0, 0.5);
+        z-index: 199;
         opacity: 0;
         pointer-events: none;
-        transition: opacity 0.3s;
+        transition: opacity 0.35s ease;
+        backdrop-filter: blur(2px);
+        -webkit-backdrop-filter: blur(2px);
     }
 
     .sidebar-overlay.active {
@@ -667,7 +747,7 @@
 
 @media (max-width: 600px) {
     .blog-content {
-        padding: 1.5rem 1rem 3rem;
+        padding: 1.5rem 1rem 6rem;
     }
 
     .article-meta h1 {

--- a/blogs/blog.js
+++ b/blogs/blog.js
@@ -53,6 +53,8 @@ function initScrollProgress() {
 // ---------- MOBILE SIDEBAR ----------
 function initMobileNav() {
     const toggle = document.getElementById('sidebar-toggle');
+    const pill = document.getElementById('mobile-posts-pill');
+    const dragHandle = document.getElementById('sidebar-drag-handle');
     const sidebar = document.getElementById('blog-sidebar');
 
     // Create overlay
@@ -63,23 +65,47 @@ function initMobileNav() {
     function openSidebar() {
         sidebar.classList.add('open');
         overlay.classList.add('active');
-        toggle.classList.add('active');
+        if (toggle) toggle.classList.add('active');
+        // Keep pill visible but flip chevron to signal "tap to close"
+        if (pill) pill.classList.add('active');
     }
 
     function closeSidebar() {
         sidebar.classList.remove('open');
         overlay.classList.remove('active');
-        toggle.classList.remove('active');
+        if (toggle) toggle.classList.remove('active');
+        // Reset pill chevron back to "browse" state
+        if (pill) pill.classList.remove('active');
     }
 
-    toggle.addEventListener('click', () => {
-        if (sidebar.classList.contains('open')) {
-            closeSidebar();
-        } else {
-            openSidebar();
-        }
-    });
+    // Floating pill — primary trigger on mobile
+    if (pill) {
+        pill.addEventListener('click', () => {
+            if (sidebar.classList.contains('open')) {
+                closeSidebar();
+            } else {
+                openSidebar();
+            }
+        });
+    }
 
+    // Legacy nav toggle (hidden on mobile, kept for desktop fallback)
+    if (toggle) {
+        toggle.addEventListener('click', () => {
+            if (sidebar.classList.contains('open')) {
+                closeSidebar();
+            } else {
+                openSidebar();
+            }
+        });
+    }
+
+    // Tapping the drag handle closes the sheet (native iOS pattern)
+    if (dragHandle) {
+        dragHandle.addEventListener('click', closeSidebar);
+    }
+
+    // Tapping the dimmed overlay closes the sheet
     overlay.addEventListener('click', closeSidebar);
 
     // Close sidebar when a post is selected on mobile

--- a/blogs/index.html
+++ b/blogs/index.html
@@ -32,15 +32,7 @@
     <nav id="nav">
         <div class="nav-inner">
             <div style="display: flex; align-items: center; gap: 0.8rem;">
-                <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Toggle blog sidebar">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
-                        stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"
-                        class="sidebar-toggle-icon">
-                        <line x1="4" y1="12" x2="20" y2="12" />
-                        <line x1="4" y1="6" x2="20" y2="6" />
-                        <line x1="4" y1="18" x2="20" y2="18" />
-                    </svg>
-                </button>
+                <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Toggle blog sidebar" title="Browse posts" style="display:none;"></button>
                 <a href="../#hero" class="logo">AK<span class="logo-dot">.</span></a>
             </div>
             <div class="nav-links" id="nav-links">
@@ -65,6 +57,8 @@
 
         <!-- Sidebar -->
         <aside class="blog-sidebar" id="blog-sidebar">
+            <!-- Drag handle (mobile bottom sheet only) -->
+            <div class="sidebar-drag-handle" id="sidebar-drag-handle" aria-hidden="true"></div>
             <div class="sidebar-header">
                 <h2>Blog</h2>
                 <div class="sidebar-search">
@@ -105,7 +99,19 @@
         </div>
     </footer>
 
-    <script src="blog.js?v=20260322"></script>
+    <!-- Floating bottom pill — mobile only, triggers bottom sheet sidebar -->
+    <button class="mobile-posts-pill" id="mobile-posts-pill" aria-label="Browse blog posts">
+        <svg class="pill-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/>
+            <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/>
+        </svg>
+        <span class="pill-label">Browse Posts</span>
+        <svg class="pill-chevron" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <polyline points="18 15 12 9 6 15"/>
+        </svg>
+    </button>
+
+    <script src="blog.js?v=20260422"></script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary

Rethinks the mobile blog navigation from scratch, replacing the top-left hamburger icon with a more intuitive **floating bottom pill + bottom sheet** pattern.

## Problem with the hamburger
- Hidden navigation = low discoverability
- Top-left corner is the hardest thumb zone on mobile
- Mystery icon gives no hint of what's behind it

## What changed

### logs/index.html
- Removed hamburger button from nav (kept as display:none for JS compatibility)
- Added drag handle inside sidebar (dismiss affordance)
- Added floating #mobile-posts-pill button before </body>

### logs/blog.css
- **Sidebar on mobile**: slides up as an 85vh bottom sheet with rounded top corners, instead of a left drawer
- **Floating pill**: accent-purple, self-labeled ('Browse Posts'), anchored to bottom-center (thumb zone), entrance animation on load
- **Pill active state**: stays visible when sheet is open; chevron rotates 180° to signal 'tap to close'
- **Overlay**: adds ackdrop-filter: blur for a premium focus-mode feel
- Extra bottom padding on content so the pill never overlaps reading text
- Desktop completely unaffected (pill is display:none above 900px)

### logs/blog.js
- initMobileNav() wired to pill, drag handle, and legacy toggle
- Pill adds .active class (chevron flip) when open, removes it on close
- Clicking the pill again while sheet is open closes it

## UX rationale

| Pattern | Reason |
|---|---|
| Bottom pill | Thumb-friendly zone (bottom-center reachable with one thumb) |
| Self-labeled | 'Browse Posts' eliminates the mystery of a hamburger icon |
| Bottom sheet | Native iOS/Android pattern — universally understood |
| Chevron flip | Signals state change without any extra text |
| Drag handle | Natural dismiss affordance matching native sheet UX |

## Screenshots
Tested at 390×844px (iPhone 14 viewport). Desktop layout unchanged.